### PR TITLE
fix(build): output assembly file with `.S` for preprocessing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # TODO: idfk
-          # - host: ubuntu-latest
-          #   target: aarch64-unknown-linux-gnu
-          #   test: true
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            test: true
           # TODO: arm
           # - host: ubuntu-latest
           #   target: arm-unknown-linux-gnueabi

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Forked from OpenSSL, [Cryptogams](https://github.com/dot-asm/cryptogams), and [R
 |:------------:|:-----:|:-----:|:-------:|
 |      x86     |   ❌   |   ❌   |    ❌    |
 |    x86_64    |   ✅   |   ✅   |    ✅    |
-|    aarch64   |   ❌   |   ✅   |    ❌    |
+|    aarch64   |   ✅   |   ✅   |    ❌    |
 | powerpc{,64} |   ✅   |  N/A  |   N/A   |
 | powerpc64le  |   ❌   |  N/A  |   N/A   |
 |    riscv32   |   ❌   |  N/A  |   N/A   |

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -11,7 +11,7 @@ fn main() {
     let script = cryptogams_script(feature);
     eprintln!("selected cryptogams script: {script}");
     let src = Path::new(script).file_stem().unwrap().to_str().unwrap();
-    let sha3 = Path::new(&env("OUT_DIR")).join(format!("{src}.s"));
+    let sha3 = Path::new(&env("OUT_DIR")).join(format!("{src}.S"));
     println!("cargo:rustc-env=SHA3_ASM_SRC={src}");
 
     let flavor = cryptogams_script_flavor(feature);
@@ -124,7 +124,7 @@ fn perl(path: &str, flavor: Option<&str>, to: &str) {
     cmd.arg(path);
     cmd.arg(flavor.unwrap_or("void"));
     let to_relative = Path::new(to);
-    let to_relative = to_relative.strip_prefix(&env::current_dir().unwrap()).unwrap_or(to_relative);
+    let to_relative = to_relative.strip_prefix(env::current_dir().unwrap()).unwrap_or(to_relative);
     let to_relative = to_relative.to_str().unwrap().replace('\\', "/");
     cmd.arg(to_relative);
 


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html

This is important for aarch64 which uses `__SIZEOF_POINTER__` & `__AARCH64EB__` that require preprocessing.

Closes #2
Fixes #4