### PR TITLE
perf: use ARM SHA3 extension symbols

### DIFF
--- a/sha3-asm/src/lib.rs
+++ b/sha3-asm/src/lib.rs
@@ -20,7 +20,14 @@ extern "C" {
     /// size_t SHA3_absorb(uint64_t A[5][5], const unsigned char *inp, size_t len,
     ///                    size_t r);
     /// ```
-    #[link_name = "KECCAK_ASM_SHA3_absorb"]
+    #[cfg_attr(
+        all(target_arch = "aarch64", target_feature = "sha3"),
+        link_name = "KECCAK_ASM_SHA3_absorb_cext"
+    )]
+    #[cfg_attr(
+        not(all(target_arch = "aarch64", target_feature = "sha3")),
+        link_name = "KECCAK_ASM_SHA3_absorb"
+    )]
     pub fn SHA3_absorb(a: *mut Buffer, inp: *const u8, len: usize, r: usize) -> usize;
 
     /// SHA-3 squeeze, defined in assembly.
@@ -32,7 +39,14 @@ extern "C" {
     /// ```c
     /// void SHA3_squeeze(uint64_t A[5][5], unsigned char *out, size_t len, size_t r);
     /// ```
-    #[link_name = "KECCAK_ASM_SHA3_squeeze"]
+    #[cfg_attr(
+        all(target_arch = "aarch64", target_feature = "sha3"),
+        link_name = "KECCAK_ASM_SHA3_squeeze_cext"
+    )]
+    #[cfg_attr(
+        not(all(target_arch = "aarch64", target_feature = "sha3")),
+        link_name = "KECCAK_ASM_SHA3_squeeze"
+    )]
     pub fn SHA3_squeeze(a: *mut Buffer, out: *mut u8, len: usize, r: usize);
 }
 


### PR DESCRIPTION
On aarch64 targets with the `sha3` target feature enabled, bind the Rust FFI to the generated Cryptogams `*_cext` symbols. The build script already emits and renames these symbols when it generates the ARMv8.2 SHA3 implementation; this change makes the public absorb/squeeze bindings use them on capable targets while preserving the existing scalar symbols elsewhere.

This matches OpenSSL's current aarch64 SHA3 provider routing, which calls `SHA3_absorb_cext` when SHA3 extensions are available and worth using.

Local validation on Apple M3 Ultra:

- `cargo fmt --all --check`
- `cargo test --workspace`
- `RUSTFLAGS='-C target-cpu=native' cargo test --workspace`

Local microbenchmarks against `alloy-primitives` Keccak256 with `RUSTFLAGS='-C target-cpu=native'` showed median improvements around 5-9% across 20, 32, 64, 136, and 1024 byte inputs.
