### PR TITLE
Select SHA3 link names in build script

### DIFF
--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -74,14 +74,7 @@ fn link_name(target: &Target, prefix: &str, symbol: &str) -> String {
     // OpenSSL only wires the ARM SHA3 cext absorb symbol because its squeeze
     // path uses a newer five-argument ABI. These cryptogams sources expose the
     // old four-argument ABI, so both cext symbols match our direct bindings.
-    let suffix = if matches!(symbol, "SHA3_absorb" | "SHA3_squeeze")
-        && target.arch == "aarch64"
-        && target.has_feature("sha3")
-    {
-        "_cext"
-    } else {
-        ""
-    };
+    let suffix = if target.arch == "aarch64" && target.has_feature("sha3") { "_cext" } else { "" };
     format!("{prefix}_{symbol}{suffix}")
 }
 

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -11,6 +11,16 @@ fn main() {
     let sha3 = Path::new(&env("OUT_DIR")).join(format!("{src}.{ext}"));
     println!("cargo:rustc-env=SHA3_ASM_SRC={src}");
 
+    let symbol_prefix = "KECCAK_ASM";
+    println!(
+        "cargo:rustc-env=SHA3_ASM_ABSORB={}",
+        link_name(&target, symbol_prefix, "SHA3_absorb")
+    );
+    println!(
+        "cargo:rustc-env=SHA3_ASM_SQUEEZE={}",
+        link_name(&target, symbol_prefix, "SHA3_squeeze")
+    );
+
     let flavor = cryptogams_script_flavor(&target);
     eprintln!("selected cryptogams script flavor: {flavor:?}");
     run_perlasm(&script, flavor.as_deref(), &sha3);
@@ -28,7 +38,6 @@ fn main() {
     // hash results.
     //
     // Instead, we rename the symbols with a prefix, so that the symbols do not conflict.
-    let symbol_prefix = "KECCAK_ASM";
     let preprocessor_renames = ["SHA3_squeeze", "SHA3_absorb"];
 
     cc.file(&sha3);
@@ -48,18 +57,29 @@ fn main() {
     } else {
         // we do not want to define anything for msvc + arm
         for symbol in preprocessor_renames {
-            // symbols with a _cext suffix are also shared
-            let symbol_cext = format!("{symbol}_cext");
-            for symbol in [symbol, &symbol_cext] {
+            for suffix in ["", "_cext", "_neon", "_kimd"] {
+                let symbol = format!("{symbol}{suffix}");
                 // sometimes the symbols have underscores
                 cc.define(&format!("_{symbol}"), format!("_{symbol_prefix}_{symbol}").as_str());
                 // and sometimes they do not
-                cc.define(symbol, format!("{symbol_prefix}_{symbol}").as_str());
+                cc.define(&symbol, format!("{symbol_prefix}_{symbol}").as_str());
             }
         }
     }
 
     cc.compile("keccak");
+}
+
+fn link_name(target: &Target, prefix: &str, symbol: &str) -> String {
+    // Match OpenSSL's ARM SHA3 provider path: only absorb is routed to the cext
+    // symbol, while squeeze stays on the base implementation.
+    let suffix =
+        if symbol == "SHA3_absorb" && target.arch == "aarch64" && target.has_feature("sha3") {
+            "_cext"
+        } else {
+            ""
+        };
+    format!("{prefix}_{symbol}{suffix}")
 }
 
 fn cryptogams_script(target: &Target) -> &'static str {

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -71,14 +71,17 @@ fn main() {
 }
 
 fn link_name(target: &Target, prefix: &str, symbol: &str) -> String {
-    // Match OpenSSL's ARM SHA3 provider path: only absorb is routed to the cext
-    // symbol, while squeeze stays on the base implementation.
-    let suffix =
-        if symbol == "SHA3_absorb" && target.arch == "aarch64" && target.has_feature("sha3") {
-            "_cext"
-        } else {
-            ""
-        };
+    // OpenSSL only wires the ARM SHA3 cext absorb symbol because its squeeze
+    // path uses a newer five-argument ABI. These cryptogams sources expose the
+    // old four-argument ABI, so both cext symbols match our direct bindings.
+    let suffix = if matches!(symbol, "SHA3_absorb" | "SHA3_squeeze")
+        && target.arch == "aarch64"
+        && target.has_feature("sha3")
+    {
+        "_cext"
+    } else {
+        ""
+    };
     format!("{prefix}_{symbol}{suffix}")
 }
 

--- a/sha3-asm/src/lib.rs
+++ b/sha3-asm/src/lib.rs
@@ -20,14 +20,7 @@ extern "C" {
     /// size_t SHA3_absorb(uint64_t A[5][5], const unsigned char *inp, size_t len,
     ///                    size_t r);
     /// ```
-    #[cfg_attr(
-        all(target_arch = "aarch64", target_feature = "sha3"),
-        link_name = "KECCAK_ASM_SHA3_absorb_cext"
-    )]
-    #[cfg_attr(
-        not(all(target_arch = "aarch64", target_feature = "sha3")),
-        link_name = "KECCAK_ASM_SHA3_absorb"
-    )]
+    #[link_name = env!("SHA3_ASM_ABSORB")]
     pub fn SHA3_absorb(a: *mut Buffer, inp: *const u8, len: usize, r: usize) -> usize;
 
     /// SHA-3 squeeze, defined in assembly.
@@ -39,14 +32,7 @@ extern "C" {
     /// ```c
     /// void SHA3_squeeze(uint64_t A[5][5], unsigned char *out, size_t len, size_t r);
     /// ```
-    #[cfg_attr(
-        all(target_arch = "aarch64", target_feature = "sha3"),
-        link_name = "KECCAK_ASM_SHA3_squeeze_cext"
-    )]
-    #[cfg_attr(
-        not(all(target_arch = "aarch64", target_feature = "sha3")),
-        link_name = "KECCAK_ASM_SHA3_squeeze"
-    )]
+    #[link_name = env!("SHA3_ASM_SQUEEZE")]
     pub fn SHA3_squeeze(a: *mut Buffer, out: *mut u8, len: usize, r: usize);
 }
 


### PR DESCRIPTION
This moves the selected assembly symbol names into build-script generated env vars and uses `env!()` from the extern declarations. The Rust bindings no longer need target cfgs for `link_name`; the build script owns both the generated assembly flavor and the symbol names that flavor exposes.

On ARMv8.2 SHA3 targets, the build script selects the `_cext` variants for both `SHA3_absorb` and `SHA3_squeeze`. OpenSSL provides useful history here: the cext absorb and squeeze symbols were both added in openssl/openssl#5358, while the later provider wiring in openssl/openssl#21398 only routed absorb through `SHA3_absorb_cext`. That OpenSSL limitation does not directly apply here, because OpenSSL later changed its base `SHA3_squeeze` interface for resumable `EVP_DigestSqueeze()` in openssl/openssl@536649082212e7c643ab8d7bab89f620fbcd37f0 by adding a fifth `next` argument. The bundled cryptogams sources in this crate still expose the four-argument squeeze ABI that our Rust binding uses, so `SHA3_squeeze_cext` is ABI-compatible for us.

The renaming pass now covers the suffix variants emitted by the supported cryptogams scripts, so generated symbols like `_cext`, `_neon`, and `_kimd` get the same private `KECCAK_ASM_` prefix as the base `SHA3_absorb` and `SHA3_squeeze` names.
