### PR TITLE
Update cryptogams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
       - name: build
         if: ${{ !matrix.test }}
         shell: bash
@@ -157,6 +158,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
       - run: cargo build --workspace
         env:
           RUSTFLAGS: -Dwarnings
@@ -172,6 +174,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
       - run: cargo clippy --workspace --all-targets
         env:
           RUSTFLAGS: -Dwarnings
@@ -190,6 +193,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-bin: false
       - run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: --cfg docsrs -D warnings --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -111,9 +111,11 @@ fn cryptogams_script(target: &Target) -> &'static str {
             }
         }
         "x86_64" => {
-            if target.has_feature("apxf") {
-                "cryptogams/x86_64/keccak1600-apx.pl"
-            } else if target.has_feature("avx512vl") {
+            // TODO: OpenSSL has not enabled this yet.
+            // if target.has_feature("apxf") {
+            //     "cryptogams/x86_64/keccak1600-apx.pl"
+            // } else
+            if target.has_feature("avx512vl") {
                 "cryptogams/x86_64/keccak1600-avx512vl.pl"
             // These are obsolete, plain x86_64 implementation is faster:
             // https://github.com/DaniPopes/bench-keccak256

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -111,7 +111,9 @@ fn cryptogams_script(target: &Target) -> &'static str {
             }
         }
         "x86_64" => {
-            if target.has_feature("avx512vl") {
+            if target.has_feature("apxf") {
+                "cryptogams/x86_64/keccak1600-apx.pl"
+            } else if target.has_feature("avx512vl") {
                 "cryptogams/x86_64/keccak1600-avx512vl.pl"
             // These are obsolete, plain x86_64 implementation is faster:
             // https://github.com/DaniPopes/bench-keccak256


### PR DESCRIPTION
This updates the bundled cryptogams submodule from `65daf83` to `680f98c`.

The relevant upstream delta for this crate is the refreshed RISC-V keccak implementation. The submodule update also brings in new upstream keccak scripts for x86_64 APX and SPARC OSA2017, but they are intentionally left unselected for now. OpenSSL has not enabled the APX keccak backend, and the SPARC OSA2017 file is a SHA3-instruction path rather than a generic SPARC implementation.

The existing backend selection remains unchanged: x86_64 still prefers AVX512VL when requested and otherwise uses the plain x86_64 cryptogams path.
