### PR TITLE
fix(build): OUT_DIR symlink source truncation + exact patch matching; add avx512 CFI patch

### DIFF
--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -217,6 +217,13 @@ fn maybe_patch_script<'a>(script: &'a str) -> Cow<'a, str> {
 
     let out_dir = env("OUT_DIR");
     let patched = Path::new(&out_dir).join(script_name);
+    // The sibling-symlink loop below may have planted `OUT_DIR/<script_name>` as a
+    // symlink back to the source on a previous run that selected a different script
+    // (the build script re-runs in the same OUT_DIR when e.g. `SHA3_ASM_SCRIPT`
+    // changes). `fs::copy` follows the symlink and opens the destination with
+    // truncate, which would zero out the checked-in source before reading it.
+    // Remove whatever is at the destination so the copy creates a fresh file.
+    let _ = fs::remove_file(&patched);
     fs::copy(script, &patched).unwrap();
 
     // Symlink sibling files (e.g. x86_64-xlate.pl) so patched scripts can find them.

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -196,8 +196,16 @@ fn maybe_patch_script<'a>(script: &'a str) -> Cow<'a, str> {
             let e = e.unwrap();
             let name = e.file_name();
             let name = name.to_str().unwrap();
+            // Patches are named `<script-stem>-<suffix>.patch`; match the stem exactly
+            // (split at the last '-') rather than as a substring, otherwise e.g.
+            // `keccak1600-avx512vl-cfi.patch` also matches `keccak1600-avx512.pl`,
+            // whose stem is a prefix of the VL one.
+            let stem = script_path.file_stem().unwrap().to_str().unwrap();
             if name.ends_with(".patch")
-                && name.contains(script_path.file_stem().unwrap().to_str().unwrap())
+                && name
+                    .trim_end_matches(".patch")
+                    .rsplit_once('-')
+                    .is_some_and(|(patch_stem, _)| patch_stem == stem)
             {
                 Some(e.path())
             } else {

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -202,10 +202,10 @@ fn maybe_patch_script<'a>(script: &'a str) -> Cow<'a, str> {
             // whose stem is a prefix of the VL one.
             let stem = script_path.file_stem().unwrap().to_str().unwrap();
             if name.ends_with(".patch")
-                && name
-                    .trim_end_matches(".patch")
-                    .rsplit_once('-')
-                    .is_some_and(|(patch_stem, _)| patch_stem == stem)
+                && matches!(
+                    name.trim_end_matches(".patch").rsplit_once('-'),
+                    Some((patch_stem, _)) if patch_stem == stem
+                )
             {
                 Some(e.path())
             } else {

--- a/sha3-asm/patches/keccak1600-avx512-cfi.patch
+++ b/sha3-asm/patches/keccak1600-avx512-cfi.patch
@@ -1,0 +1,98 @@
+--- a/keccak1600-avx512.pl
++++ b/keccak1600-avx512.pl
+@@ -128,12 +128,25 @@
+ my ($C00,$D00) = @T[0..1];
+ my ($k00001,$k00010,$k00100,$k01000,$k10000,$k11111) = map("%k$_",(1..6));
+ 
++$flavour = shift;
++$output  = shift;
++if ($flavour =~ /\./) { $output = $flavour; undef $flavour; }
++
++$0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
++( $xlate="${dir}x86_64-xlate.pl" and -f $xlate ) or
++( $xlate="${dir}../../perlasm/x86_64-xlate.pl" and -f $xlate) or
++die "can't locate x86_64-xlate.pl";
++
++open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\"";
++*STDOUT=*OUT;
++
+ $code.=<<___;
+ .text
+ 
+ .type	__KeccakF1600,\@function
+ .align	32
+ __KeccakF1600:
++.cfi_startproc
+ 	lea		iotas(%rip),%r10
+ 	mov		\$12,%eax
+ 	jmp		.Loop_avx512
+@@ -270,6 +283,7 @@
+ 	jnz		.Loop_avx512
+ 
+ 	ret
++.cfi_endproc
+ .size	__KeccakF1600,.-__KeccakF1600
+ ___
+ 
+@@ -278,9 +292,14 @@
+ 
+ $code.=<<___;
+ .globl	SHA3_absorb
+-.type	SHA3_absorb,\@function
++.type	SHA3_absorb,\@function,4
+ .align	32
+ SHA3_absorb:
++.cfi_startproc
++	push	%rbp
++.cfi_push	%rbp
++	mov	%rsp,%rbp
++.cfi_def_cfa_register	%rbp
+ 	mov	%rsp,%r11
+ 
+ 	lea	-320(%rsp),%rsp
+@@ -380,13 +399,22 @@
+ 
+ 	lea	(%r11),%rsp
+ 	lea	($len,$bsz),%rax		# return value
++	pop	%rbp
++.cfi_restore	%rbp
++.cfi_def_cfa	%rsp,8
+ 	ret
++.cfi_endproc
+ .size	SHA3_absorb,.-SHA3_absorb
+ 
+ .globl	SHA3_squeeze
+-.type	SHA3_squeeze,\@function
++.type	SHA3_squeeze,\@function,4
+ .align	32
+ SHA3_squeeze:
++.cfi_startproc
++	push	%rbp
++.cfi_push	%rbp
++	mov	%rsp,%rbp
++.cfi_def_cfa_register	%rbp
+ 	mov	%rsp,%r11
+ 
+ 	lea	96($A_flat),$A_flat
+@@ -480,7 +508,11 @@
+ 	vzeroupper
+ 
+ 	lea	(%r11),%rsp
++	pop	%rbp
++.cfi_restore	%rbp
++.cfi_def_cfa	%rsp,8
+ 	ret
++.cfi_endproc
+ .size	SHA3_squeeze,.-SHA3_squeeze
+ 
+ .align	64
+@@ -542,5 +574,8 @@
+ .asciz	"Keccak-1600 absorb and squeeze for AVX-512F, CRYPTOGAMS by <appro\@openssl.org>"
+ ___
+ 
+-print $code;
++foreach (split("\n",$code)) {
++	print $_, "\n";
++}
++
+ close STDOUT;


### PR DESCRIPTION
Two build-script bugfixes plus a CFI patch for the AVX-512F script, found while benchmarking keccak variants on Zen 5.

## 1. `fs::copy` in `maybe_patch_script` can truncate the checked-in source `.pl` to zero bytes

The sibling-symlink loop plants `OUT_DIR/<other-script>.pl → <source>` for every sibling of the selected script. When a later run of the build script in the **same** OUT_DIR selects a different script — which happens with the documented `SHA3_ASM_SCRIPT` override, since `rerun-if-env-changed` re-runs the script in place — `fs::copy(script, OUT_DIR/<script_name>)` hits the stale symlink pointing back at the source. The copy follows the symlink and opens the destination with truncate, zeroing the source before reading it. In a registry install this corrupts the cached crate sources for every project on the machine; in a git checkout it eats the submodule file (this happened to me mid-benchmark).

Fix: `fs::remove_file(&patched)` before the copy.

Repro on master (destroys the submodule file — `git checkout` it after):
```sh
RUSTFLAGS='-C target-cpu=native' cargo build -p sha3-asm          # selects avx512vl, plants symlinks
SHA3_ASM_SCRIPT=cryptogams/x86_64/keccak1600-avx512.pl \
RUSTFLAGS='-C target-cpu=native' cargo build -p sha3-asm          # truncates keccak1600-avx512.pl
```

## 2. Patch matching is substring-based

`name.contains(stem)` makes `keccak1600-avx512vl-cfi.patch` also match `keccak1600-avx512.pl` (its stem is a prefix of the VL one), so selecting the AVX-512F script via `SHA3_ASM_SCRIPT` applies the VL patch to it and the build fails. Fixed by matching the `<script-stem>-<suffix>.patch` convention exactly (split at the last `-`).

## 3. CFI patch for `keccak1600-avx512.pl`

Same shape as the existing VL patch (xlate driver, `.cfi` annotations, rbp frames), so the AVX-512F script builds with proper unwind info when selected. With #2 fixed, `SHA3_ASM_SCRIPT=cryptogams/x86_64/keccak1600-avx512.pl` now works out of the box.

## Why I was poking at this: avx512 is not obsolete on Zen 4/5

The build.rs comment ("These are obsolete, plain x86_64 implementation is faster", citing bench-keccak256) doesn't hold on Zen 5's native 512-bit datapath. On a Ryzen 9 9950X (pinned-TSC, 25 epochs, best-of, Keccak-256 cycles/hash, both built with `-C target-cpu=native`):

| input | keccak1600-avx512vl | keccak1600-avx512 | delta |
|---|---|---|---|
| 32 B | 907 | 838 | −7.6% |
| 64 B | 901 | 825 | −8.4% |
| 136 B | 1822 | 1599 | −12.2% |
| 512 B | 3665 | 3137 | −14.4% |

~11% geomean cycles/byte over a 32–512 B workload, and more vs the default scalar selection. I have **not** changed the default selection in this PR — cargo exposes no vendor/µarch info at build time, so "ZMM on Zen 4/5, VL on Intel" isn't expressible without runtime dispatch or an opt-in feature; that seems like your call. These fixes at least make the AVX-512F path testable so others can reproduce. Happy to share the bench harness, and might be worth re-running bench-keccak256 on a Zen 4/5 part.

Tested: `cargo test` green with the default selection and with `SHA3_ASM_SCRIPT=cryptogams/x86_64/keccak1600-avx512.pl`, both under `-C target-cpu=native`; the override sequence that previously truncated the source now leaves the submodule clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
