### PR TITLE
perf(build): prefer scalar keccak on Zen 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ Forked from OpenSSL, [Cryptogams](https://github.com/dot-asm/cryptogams), and [R
 - 🟨: Compiles, but is only built, not tested in CI. Should still work normally.
 - ✅: Fully supported, with full CI coverage for the most popular target triples, e.g. `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`.
 
+## x86_64 implementation selection
+
+`sha3-asm` selects one Cryptogams backend at compile time. Set `SHA3_ASM_SCRIPT` to a relative script path to override it.
+
+Default policy:
+
+- use scalar `x86_64` for Zen 5-looking targets
+- use `avx512vl` when available otherwise
+- fall back to scalar `x86_64`
+
+Benchmarks showed `avx512vl` winning on Ryzen 9 7950X, while EPYC 4585PX Zen 5 preferred `x86_64` for tiny inputs and plain `avx512` for larger inputs. `x86_64` is the safer single default on that Zen 5 host. See [`bench-keccak256`](https://github.com/DaniPopes/bench-keccak256) for measurements.
+
 ## License
 
 Cryptogams is either licensed under [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) (the "new" BSD license, as specified [here](https://www.openssl.org/~appro/cryptogams/)), or the Linux Kernel's license [GPL-2.0-only](https://spdx.org/licenses/GPL-2.0-only.html).

--- a/README.md
+++ b/README.md
@@ -25,18 +25,6 @@ Forked from OpenSSL, [Cryptogams](https://github.com/dot-asm/cryptogams), and [R
 - 🟨: Compiles, but is only built, not tested in CI. Should still work normally.
 - ✅: Fully supported, with full CI coverage for the most popular target triples, e.g. `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`.
 
-## x86_64 implementation selection
-
-`sha3-asm` selects one Cryptogams backend at compile time. Set `SHA3_ASM_SCRIPT` to a relative script path to override it.
-
-Default policy:
-
-- use scalar `x86_64` for Zen 5-looking targets
-- use `avx512vl` when available otherwise
-- fall back to scalar `x86_64`
-
-Benchmarks showed `avx512vl` winning on Ryzen 9 7950X, while EPYC 4585PX Zen 5 preferred `x86_64` for tiny inputs and plain `avx512` for larger inputs. `x86_64` is the safer single default on that Zen 5 host. See [`bench-keccak256`](https://github.com/DaniPopes/bench-keccak256) for measurements.
-
 ## License
 
 Cryptogams is either licensed under [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) (the "new" BSD license, as specified [here](https://www.openssl.org/~appro/cryptogams/)), or the Linux Kernel's license [GPL-2.0-only](https://spdx.org/licenses/GPL-2.0-only.html).

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -110,6 +110,7 @@ fn cryptogams_script(target: &Target) -> &'static str {
                 panic!("x86 targets require MMX support")
             }
         }
+        // See https://github.com/DaniPopes/bench-keccak256 for why this order is chosen.
         "x86_64" => {
             // TODO: OpenSSL has not enabled this yet.
             // if target.has_feature("apxf") {
@@ -119,9 +120,6 @@ fn cryptogams_script(target: &Target) -> &'static str {
                 "cryptogams/x86_64/keccak1600-x86_64.pl"
             } else if target.has_feature("avx512vl") {
                 "cryptogams/x86_64/keccak1600-avx512vl.pl"
-            // These are obsolete, plain x86_64 implementation is faster:
-            // https://github.com/DaniPopes/bench-keccak256
-
             // } else if target.has_feature("avx512f") {
             //     "cryptogams/x86_64/keccak1600-avx512.pl"
             // } else if target.has_feature("avx2") {

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -339,9 +339,12 @@ impl Target {
     }
 
     fn is_zen5_target(&self) -> bool {
-        // Cargo/rustc do not expose an x86 CPU family/model cfg. For native Zen 5,
-        // the target feature set includes these two features; Zen 4 lacks both,
-        // and Sapphire Rapids lacks avx512vp2intersect.
+        // Cargo/rustc do not expose an x86 CPU family/model cfg. This is a
+        // target-feature heuristic, not exact CPU identification: native Zen 5
+        // expands to both features below, while Zen 4 lacks both. The checked
+        // Intel target CPUs do not set both: Tiger Lake has avx512vp2intersect
+        // without avxvnni, and newer Intel server CPUs have avxvnni without
+        // avx512vp2intersect. Explicit feature flags can still fool this.
         rustflags_codegen_option_is("target-cpu", "znver5")
             || self.is_native_zen5_target()
             || self.has_zen5_target_features()

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -117,7 +117,7 @@ fn cryptogams_script(target: &Target) -> &'static str {
             //     "cryptogams/x86_64/keccak1600-apx.pl"
             // } else
             if target.is_zen5_target() {
-                "cryptogams/x86_64/keccak1600-avx512.pl"
+                "cryptogams/x86_64/keccak1600-x86_64.pl"
             } else if target.has_feature("avx512vl") {
                 "cryptogams/x86_64/keccak1600-avx512vl.pl"
             // } else if target.has_feature("avx512f") {

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -115,7 +115,9 @@ fn cryptogams_script(target: &Target) -> &'static str {
             // if target.has_feature("apxf") {
             //     "cryptogams/x86_64/keccak1600-apx.pl"
             // } else
-            if target.has_feature("avx512vl") {
+            if target.is_zen5_target() {
+                "cryptogams/x86_64/keccak1600-x86_64.pl"
+            } else if target.has_feature("avx512vl") {
                 "cryptogams/x86_64/keccak1600-avx512vl.pl"
             // These are obsolete, plain x86_64 implementation is faster:
             // https://github.com/DaniPopes/bench-keccak256
@@ -335,6 +337,56 @@ impl Target {
         // The ARM SHA3 crypto extension path has only been tested to perform better on Apple.
         self.arch == "aarch64" && self.vendor == "apple" && self.has_feature("sha3")
     }
+
+    fn is_zen5_target(&self) -> bool {
+        // Cargo/rustc do not expose an x86 CPU family/model cfg. For native Zen 5,
+        // the target feature set includes these two features; Zen 4 lacks both,
+        // and Sapphire Rapids lacks avx512vp2intersect.
+        rustflags_codegen_option_is("target-cpu", "znver5")
+            || self.is_native_zen5_target()
+            || self.has_zen5_target_features()
+    }
+
+    fn is_native_zen5_target(&self) -> bool {
+        rustflags_codegen_option_is("target-cpu", "native") && self.has_zen5_target_features()
+    }
+
+    fn has_zen5_target_features(&self) -> bool {
+        self.has_feature("avx512vp2intersect") && self.has_feature("avxvnni")
+    }
+}
+
+fn rustflags_codegen_option_is(key: &str, value: &str) -> bool {
+    match maybe_env("CARGO_ENCODED_RUSTFLAGS") {
+        Ok(flags) => {
+            let mut codegen = false;
+            for flag in flags.split('\x1f') {
+                if flag == "-C" || flag == "--codegen" {
+                    codegen = true;
+                } else if let Some(option) = flag.strip_prefix("-C") {
+                    if codegen_option_is(option, key, value) {
+                        return true;
+                    }
+                } else if let Some(option) = flag.strip_prefix("--codegen=") {
+                    if codegen_option_is(option, key, value) {
+                        return true;
+                    }
+                } else if codegen {
+                    if codegen_option_is(flag, key, value) {
+                        return true;
+                    }
+                    codegen = false;
+                }
+            }
+
+            false
+        }
+        Err(_) => false,
+    }
+}
+
+fn codegen_option_is(option: &str, key: &str, value: &str) -> bool {
+    option.strip_prefix(key).and_then(|option| option.strip_prefix('=')) == Some(value)
 }
 
 #[track_caller]

--- a/sha3-asm/build.rs
+++ b/sha3-asm/build.rs
@@ -117,7 +117,7 @@ fn cryptogams_script(target: &Target) -> &'static str {
             //     "cryptogams/x86_64/keccak1600-apx.pl"
             // } else
             if target.is_zen5_target() {
-                "cryptogams/x86_64/keccak1600-x86_64.pl"
+                "cryptogams/x86_64/keccak1600-avx512.pl"
             } else if target.has_feature("avx512vl") {
                 "cryptogams/x86_64/keccak1600-avx512vl.pl"
             // } else if target.has_feature("avx512f") {


### PR DESCRIPTION
This changes the x86_64 backend selection to avoid AVX512VL on Zen 5-looking targets. The build script can now recognize `-Ctarget-cpu=znver5`, split `-C target-cpu=znver5` forms, `--codegen=target-cpu=znver5`, and native Zen 5 feature expansion from Cargo's target state instead of probing host CPUID.

The benchmark reason is that EPYC 4585PX Zen 5 preferred scalar `x86_64` for 8 and 32 byte inputs, while plain `avx512` only pulled slightly ahead for larger inputs. `avx512vl` was about 15-18% slower than scalar on that Zen 5 host, and `avx2` was about 33-38% slower. Ryzen 9 7950X Zen 4 still preferred `avx512vl`, so the existing AVX512VL path remains the default for non-Zen 5 AVX512VL targets.
